### PR TITLE
Image versions now use the corresponding tps version, not own repo tags

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -10,13 +10,16 @@ on:
   push:
     branches:
       - 'main'
-    # Publish semver tags as releases.
-    tags: [ 'v*.*' ]
+    tags:
+      - 'v*.*'
+  schedule:
+    - cron: '0 2 * * *'  # every day at 2:00 UTC
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: docker.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: goldbricklemon/tonie-podcast-sync
+  TPS_VERSIONS: '["3.3.2", "3.3.3", "main"]'
 
 jobs:
   build:
@@ -25,6 +28,7 @@ jobs:
 
     strategy:
       matrix:
+        tps_version: [ "3.3.2", "3.3.3", "main" ]
         variant:
           - name: default
             image_suffix: ""
@@ -43,6 +47,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set latest tps version
+        id: set-latest-tps
+        run: |
+          versions=$(echo '${{ env.TPS_VERSIONS }}' | jq -r '.[]' | grep -v main | sort -V)
+          latest=$(echo "$versions" | tail -n1)
+          echo "LATEST_TPS_VERSION=$latest" >> $GITHUB_ENV
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -73,33 +84,48 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
+      # Decide on image tags based on event type and TPS version
+      # Build for tps releases on tag pushes (+ latest alias)
+      # Build for tps main on main branch pushes and scheduled runs (nightly)
+      - name: Set image tags
+        id: set-tags
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ refs/tags/v && "${{ matrix.tps_version }}" != "main" ]]; then
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.tps_version }}${{ matrix.variant.image_suffix }}"
+            if [[ "${{ matrix.tps_version }}" == "$LATEST_TPS_VERSION" ]]; then
+              TAGS+="\n${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest${{ matrix.variant.image_suffix }}"
+            fi
+            echo -e "TAGS=$TAGS" >> $GITHUB_OUTPUT
+          elif ([[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.event_name }}" == "schedule" ]]) && [[ "${{ matrix.tps_version }}" == "main" ]]; then
+            echo "TAGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly${{ matrix.variant.image_suffix }}" >> $GITHUB_OUTPUT
+          else
+            echo "TAGS=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=auto
-            prefix=
-            suffix=${{ matrix.variant.image_suffix }},onlatest=true
-          tags: |
-
-            type=semver,pattern={{version}}
-            type=ref,event=branch,prefix=pre-release-
-          
+          tags: ${{ steps.set-tags.outputs.TAGS }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.tps_version != 'main') ||
+          ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && matrix.tps_version == 'main'
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
-          build-args: ${{ matrix.variant.buildargs }}
+          build-args: |
+            TPS_VERSION=${{ matrix.tps_version }}
+            ${{ matrix.variant.buildargs }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,31 @@
 FROM python:3.12.11-slim-bullseye
 
 ARG INCLUDE_FFMPEG=true
+ARG TPS_VERSION
+
+RUN if [ -z "$TPS_VERSION" ]; then \
+    echo "TPS_VERSION build argument must be provided" >&2; exit 1; \
+fi
 
 RUN apt-get update && \
     if [ "$INCLUDE_FFMPEG" = "true" ]; then \
         apt-get -y --no-install-recommends install ffmpeg; \
     fi && \
     apt-get -y --no-install-recommends install cron && \
-    pip install --root-user-action ignore tonie-podcast-sync==3.3.3 && \
+    if [ "$TPS_VERSION" = "main" ]; then \
+        apt-get -y --no-install-recommends install git && \
+        git clone --depth 1 https://github.com/goldbricklemon/tonie-podcast-sync.git /tmp/tps && \
+        pip install --root-user-action ignore /tmp/tps && \
+        rm -rf /tmp/tps; \
+    else \
+        pip install --root-user-action ignore tonie-podcast-sync==${TPS_VERSION}; \
+    fi && \
     mkdir -p /root/.toniepodcastsync
 
 WORKDIR /src
 
 COPY src/start_schedule.sh .
 RUN chmod +x start_schedule.sh
-
 
 ENTRYPOINT [ "./start_schedule.sh" ]
 CMD ["cron", "-f"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You further need to inject the `settings.toml` as well as your Tonie Cloud crede
 
 #### A)
 I case you want to pass your credentials via the
-`.secrets.toml` file into the contianer, just
+`.secrets.toml` file into the container, just
 bind-mount the complete `.toniepodcastsync` directory. This obviously **requires** the `.secrects.toml` file to be present.
 
 The minimal `docker run` command would look like this:
@@ -98,8 +98,8 @@ Truth be told, this container is pretty much a glorified containerized `cron` th
   * ~~The container image is currently far too large for what it brings. Options:~~
     + ~~Offer a non-`ffmpeg` version~~
     + Migrate to `alpine` (although python applications under `alpine` can be iffy)
-  * Re-work the version/tag system of the docker image to reflect the used version of `tonie-podcast-sync`
-    * Additionally offer a `pre-release` image that is in sync with `main` of `tonie-podcast-sync` to get the most recent changes without a dedicated release
+  * ~~Re-work the version/tag system of the docker image to reflect the used version of `tonie-podcast-sync`~~
+    * ~~Additionally offer a `nightly` image that is in sync with `main` of `tonie-podcast-sync` to get the most recent changes without a dedicated release~~
   * Run as non-root user (will lead to breaking changes, so no priority for now)
     
 ## Builds Upon / Thanks To


### PR DESCRIPTION
- Image versions are now built for a predefined set of tps versions.
- The image names reflect those versions, and not the tags of this repo
- The :latest tag references the highest tps version that is built for.
- A nightly build uses the current main-branch of tps